### PR TITLE
chore: Update invoice filename

### DIFF
--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -108,16 +108,16 @@ final class Invoice implements InvoiceInterface
     /**
      * Get the default filename for the invoice.
      *
-     * format: {translatable-base}-{date|concept}.pdf
-     * example: invoice-20260119.pdf or factuur-20260119.pdf
+     * format: {translatable-base}-{serial}.pdf
+     * example: invoice-INV.00000123.pdf or factuur-INV.00000123.pdf
      */
     public function getFilename(): string
     {
         // use the invoice's language for translation
         $base = __('invoices::invoice.filename', [], $this->getLanguage());
-        $dateString = $this->getDate()?->format('Ymd') ?? __('invoices::invoice.concept', [], $this->getLanguage());
+        $serial = $this->getSerial() ?? __('invoices::invoice.concept', [], $this->getLanguage());
 
-        return "{$base}-{$dateString}.pdf";
+        return "{$base}-{$serial}.pdf";
     }
 
     /**

--- a/tests/Feature/Invoice/PdfGenerationTest.php
+++ b/tests/Feature/Invoice/PdfGenerationTest.php
@@ -162,7 +162,7 @@ final class PdfGenerationTest extends TestCase
         // arrange
         $invoice = $this->createValidInvoice();
         $invoice->language('en'); // explicitly set english for deterministic filename
-        $invoice->date('2024-01-15'); // Fixed date for consistent testing
+        $invoice->serial('INV.00000123'); // fixed serial for consistent testing
         $mockPdf = $this->mockPdfInstance();
 
         $this->mockPdfFacadeChain();
@@ -185,7 +185,7 @@ final class PdfGenerationTest extends TestCase
     public static function download_filename_data_provider(): array
     {
         return [
-            'default filename' => [null, 'invoice-20240115.pdf'],
+            'default filename' => [null, 'invoice-INV.00000123.pdf'],
             'custom filename' => ['custom-invoice.pdf', 'custom-invoice.pdf'],
         ];
     }
@@ -196,7 +196,7 @@ final class PdfGenerationTest extends TestCase
         // arrange
         $invoice = $this->createValidInvoice();
         $invoice->language('en'); // explicitly set english for deterministic filename
-        $invoice->date('2024-01-15'); // Fixed date for consistent testing
+        $invoice->serial('INV.00000123'); // fixed serial for consistent testing
         $mockPdf = $this->mockPdfInstance();
 
         $this->mockPdfFacadeChain();
@@ -204,7 +204,7 @@ final class PdfGenerationTest extends TestCase
         Pdf::shouldReceive('loadView')
             ->once()
             ->andReturn($mockPdf);
-        $this->mockPdfDownload($mockPdf, 'invoice-20240115.pdf');
+        $this->mockPdfDownload($mockPdf, 'invoice-INV.00000123.pdf');
 
         // assert
         // pdf not rendered yet
@@ -245,7 +245,7 @@ final class PdfGenerationTest extends TestCase
         // arrange
         $invoice = $this->createValidInvoice();
         $invoice->language('en'); // explicitly set english for deterministic filename
-        $invoice->date('2024-01-15'); // fixed date for consistent testing
+        $invoice->serial('INV.00000123'); // fixed serial for consistent testing
         $mockPdf = $this->mockPdfInstance();
 
         $this->mockPdfFacadeChain();
@@ -269,7 +269,7 @@ final class PdfGenerationTest extends TestCase
     public static function stream_filename_data_provider(): array
     {
         return [
-            'default filename' => [null, 'invoice-20240115.pdf'],
+            'default filename' => [null, 'invoice-INV.00000123.pdf'],
             'custom filename' => ['custom-invoice.pdf', 'custom-invoice.pdf'],
         ];
     }
@@ -280,7 +280,7 @@ final class PdfGenerationTest extends TestCase
         // arrange
         $invoice = $this->createValidInvoice();
         $invoice->language('en'); // explicitly set english for deterministic filename
-        $invoice->date('2024-01-15'); // Fixed date for consistent testing
+        $invoice->serial('INV.00000123'); // fixed serial for consistent testing
         $mockPdf = $this->mockPdfInstance();
 
         $this->mockPdfFacadeChain();
@@ -289,7 +289,7 @@ final class PdfGenerationTest extends TestCase
             ->once()
             ->andReturn($mockPdf);
 
-        $this->mockPdfStream($mockPdf, 'invoice-20240115.pdf');
+        $this->mockPdfStream($mockPdf, 'invoice-INV.00000123.pdf');
 
         // act
         $response = $invoice->stream();
@@ -308,7 +308,7 @@ final class PdfGenerationTest extends TestCase
         // arrange
         $invoice = $this->createValidInvoice();
         $invoice->language('en'); // explicitly set english for deterministic filename
-        $invoice->date('2024-01-15'); // Fixed date for consistent testing
+        $invoice->serial('INV.00000123'); // fixed serial for consistent testing
         $mockPdf = $this->mockPdfInstance();
 
         $this->mockPdfFacadeChain();
@@ -317,7 +317,7 @@ final class PdfGenerationTest extends TestCase
             ->once()
             ->andReturn($mockPdf);
 
-        $this->mockPdfStream($mockPdf, 'invoice-20240115.pdf');
+        $this->mockPdfStream($mockPdf, 'invoice-INV.00000123.pdf');
 
         // assert
         // pdf not rendered yet


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Invoice filenames now use serial numbers instead of dates, formatted as {base}-{serial}.pdf (e.g., INV.00000123.pdf)
* **Tests**
  * Updated tests and expectations to reflect the new serial-based invoice filename format

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->