### PR TITLE
chore: Add custom footer messages without changing template

### DIFF
--- a/src/Contracts/InvoiceInterface.php
+++ b/src/Contracts/InvoiceInterface.php
@@ -82,7 +82,7 @@ interface InvoiceInterface
     /**
      * Set a custom footer message for issued invoices.
      *
-     * Supports :amount and :date placeholders.
+     * Supports :amount, :date and :number placeholders.
      */
     public function footerMessage(?string $message): self;
 

--- a/src/Contracts/InvoiceInterface.php
+++ b/src/Contracts/InvoiceInterface.php
@@ -80,6 +80,18 @@ interface InvoiceInterface
     public function template(string $template): self;
 
     /**
+     * Set a custom footer message for issued invoices.
+     *
+     * Supports :amount and :date placeholders.
+     */
+    public function footerMessage(?string $message): self;
+
+    /**
+     * Set a custom footer message for concept invoices.
+     */
+    public function conceptFooterMessage(?string $message): self;
+
+    /**
      * Set an expected total amount for validation purposes.
      *
      * When the invoice is rendered, if the expected total differs from the calculated total, an error will be logged.
@@ -178,6 +190,16 @@ interface InvoiceInterface
      * Get the due date formatted according to the invoice date format.
      */
     public function getFormattedDueDate(): ?string;
+
+    /**
+     * Get the custom footer message for issued invoices.
+     */
+    public function getCustomFooterMessage(): ?string;
+
+    /**
+     * Get the custom footer message for concept invoices.
+     */
+    public function getCustomConceptFooterMessage(): ?string;
 
     /**
      * Get all unique tax percentages from items.

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -101,6 +101,8 @@ final class Invoice implements InvoiceInterface
             'series' => $this->getSeries(),
             'sequence' => $this->getSequence(),
             'language' => $this->getLanguage(),
+            'footer_message' => $this->getCustomFooterMessage(),
+            'concept_footer_message' => $this->getCustomConceptFooterMessage(),
             'expected_total' => $this->getExpectedTotal(),
         ];
     }

--- a/src/Models/Traits/HasInvoiceFooter.php
+++ b/src/Models/Traits/HasInvoiceFooter.php
@@ -42,10 +42,6 @@ trait HasInvoiceFooter
      */
     public function getCustomFooterMessage(): ?string
     {
-        if ($this->footerMessage === null) {
-            return null;
-        }
-
         return e($this->footerMessage);
     }
 
@@ -54,10 +50,6 @@ trait HasInvoiceFooter
      */
     public function getCustomConceptFooterMessage(): ?string
     {
-        if ($this->conceptFooterMessage === null) {
-            return null;
-        }
-
         return e($this->conceptFooterMessage);
     }
 

--- a/src/Models/Traits/HasInvoiceFooter.php
+++ b/src/Models/Traits/HasInvoiceFooter.php
@@ -7,6 +7,52 @@ namespace SimpleParkBv\Invoices\Models\Traits;
  */
 trait HasInvoiceFooter
 {
+    protected ?string $footerMessage = null;
+
+    protected ?string $conceptFooterMessage = null;
+
+    /**
+     * Set a custom footer message for issued invoices.
+     *
+     * Supports :amount and :date placeholders.
+     *
+     * @return $this
+     */
+    public function footerMessage(?string $message): self
+    {
+        $this->footerMessage = $message;
+
+        return $this;
+    }
+
+    /**
+     * Set a custom footer message for concept invoices.
+     *
+     * @return $this
+     */
+    public function conceptFooterMessage(?string $message): self
+    {
+        $this->conceptFooterMessage = $message;
+
+        return $this;
+    }
+
+    /**
+     * Get the custom footer message for issued invoices.
+     */
+    public function getCustomFooterMessage(): ?string
+    {
+        return $this->footerMessage;
+    }
+
+    /**
+     * Get the custom footer message for concept invoices.
+     */
+    public function getCustomConceptFooterMessage(): ?string
+    {
+        return $this->conceptFooterMessage;
+    }
+
     /**
      * Get the payment request message with formatted amount and date.
      *
@@ -16,11 +62,16 @@ trait HasInvoiceFooter
     {
         // if invoice is not issued, show concept message
         if (! $this->isIssued()) {
+            if ($this->conceptFooterMessage !== null) {
+                return $this->conceptFooterMessage;
+            }
+
             return __('invoices::invoice.concept_message');
         }
 
         /** @var string $message */
-        $message = __('invoices::invoice.payment_request');
+        $message = $this->footerMessage ?? __('invoices::invoice.payment_request');
+        
         $amountHtml = '<span class="invoice__footer-amount">'.e($this->getFormattedTotal()).'</span>';
         $dateHtml = '<span class="invoice__footer-date">'.e($this->getFormattedDueDate()).'</span>';
 

--- a/src/Models/Traits/HasInvoiceFooter.php
+++ b/src/Models/Traits/HasInvoiceFooter.php
@@ -42,7 +42,11 @@ trait HasInvoiceFooter
      */
     public function getCustomFooterMessage(): ?string
     {
-        return $this->footerMessage;
+        if ($this->footerMessage === null) {
+            return null;
+        }
+
+        return e($this->footerMessage);
     }
 
     /**
@@ -50,7 +54,11 @@ trait HasInvoiceFooter
      */
     public function getCustomConceptFooterMessage(): ?string
     {
-        return $this->conceptFooterMessage;
+        if ($this->conceptFooterMessage === null) {
+            return null;
+        }
+
+        return e($this->conceptFooterMessage);
     }
 
     /**
@@ -63,14 +71,14 @@ trait HasInvoiceFooter
         // if invoice is not issued, show concept message
         if (! $this->isIssued()) {
             if ($this->conceptFooterMessage !== null) {
-                return $this->conceptFooterMessage;
+                return e($this->conceptFooterMessage);
             }
 
             return __('invoices::invoice.concept_message');
         }
 
         /** @var string $message */
-        $message = $this->footerMessage ?? __('invoices::invoice.payment_request');
+        $message = e($this->footerMessage ?? __('invoices::invoice.payment_request'));
 
         $amountHtml = '<span class="invoice__footer-amount">'.e($this->getFormattedTotal()).'</span>';
         $dateHtml = '<span class="invoice__footer-date">'.e($this->getFormattedDueDate()).'</span>';

--- a/src/Models/Traits/HasInvoiceFooter.php
+++ b/src/Models/Traits/HasInvoiceFooter.php
@@ -14,7 +14,7 @@ trait HasInvoiceFooter
     /**
      * Set a custom footer message for issued invoices.
      *
-     * Supports :amount and :date placeholders.
+     * Supports :amount, :date and :number placeholders.
      *
      * @return $this
      */
@@ -74,9 +74,14 @@ trait HasInvoiceFooter
 
         $amountHtml = '<span class="invoice__footer-amount">'.e($this->getFormattedTotal()).'</span>';
         $dateHtml = '<span class="invoice__footer-date">'.e($this->getFormattedDueDate()).'</span>';
+        $numberHtml = '<span class="invoice__footer-number">'.e($this->getNumber() ?? '').'</span>';
 
         /** @var string $result */
-        $result = str_replace([':amount', ':date'], [$amountHtml, $dateHtml], $message);
+        $result = str_replace(
+            [':amount', ':date', ':number'],
+            [$amountHtml, $dateHtml, $numberHtml],
+            $message
+        );
 
         return $result;
     }

--- a/src/Models/Traits/HasInvoiceFooter.php
+++ b/src/Models/Traits/HasInvoiceFooter.php
@@ -71,7 +71,7 @@ trait HasInvoiceFooter
 
         /** @var string $message */
         $message = $this->footerMessage ?? __('invoices::invoice.payment_request');
-        
+
         $amountHtml = '<span class="invoice__footer-amount">'.e($this->getFormattedTotal()).'</span>';
         $dateHtml = '<span class="invoice__footer-date">'.e($this->getFormattedDueDate()).'</span>';
 

--- a/tests/Unit/Models/InvoiceTest.php
+++ b/tests/Unit/Models/InvoiceTest.php
@@ -57,6 +57,8 @@ final class InvoiceTest extends TestCase
             'series' => 'INV',
             'sequence' => 1,
             'language' => 'en',
+            'footer_message' => 'Please pay :amount by :date.',
+            'concept_footer_message' => 'This is a custom concept message.',
             'expected_total' => 25.41,
         ];
 
@@ -72,6 +74,8 @@ final class InvoiceTest extends TestCase
         $this->assertEquals('INV', $invoice->getSeries());
         $this->assertEquals(1, $invoice->getSequence());
         $this->assertEquals('en', $invoice->getLanguage());
+        $this->assertEquals('Please pay :amount by :date.', $invoice->getCustomFooterMessage());
+        $this->assertEquals('This is a custom concept message.', $invoice->getCustomConceptFooterMessage());
         $this->assertEquals(25.41, $invoice->getExpectedTotal());
     }
 
@@ -201,6 +205,8 @@ final class InvoiceTest extends TestCase
         $this->assertArrayHasKey('series', $array);
         $this->assertArrayHasKey('sequence', $array);
         $this->assertArrayHasKey('language', $array);
+        $this->assertArrayHasKey('footer_message', $array);
+        $this->assertArrayHasKey('concept_footer_message', $array);
         $this->assertEquals('Test Buyer', $array['buyer']['name']);
         $this->assertCount(1, $array['items']);
     }
@@ -896,6 +902,45 @@ final class InvoiceTest extends TestCase
         $this->assertIsString($message); // @phpstan-ignore-line method.alreadyNarrowedType
         $this->assertStringContainsString('10,00', $message);
         $this->assertStringContainsString('14-02-2024', $message);
+    }
+
+    #[Test]
+    public function custom_footer_message_for_issued_invoice_supports_placeholders(): void
+    {
+        // arrange
+        $invoice = Invoice::make();
+        $buyer = Buyer::make(['name' => 'Test Buyer']);
+        $invoice->buyer($buyer);
+        $item = $this->createInvoiceItem(['title' => 'Item']);
+        $invoice->addItem($item);
+        $invoice->date('2024-01-15');
+        $invoice->payUntilDays(30);
+        $invoice->series('INV');
+        $invoice->sequence(42);
+        $invoice->footerMessage('Please pay :amount before :date for invoice :number.');
+
+        // act
+        $message = $invoice->getFooterMessage();
+
+        // assert
+        $this->assertStringContainsString('Please pay', $message);
+        $this->assertStringContainsString('10,00', $message);
+        $this->assertStringContainsString('14-02-2024', $message);
+        $this->assertStringContainsString('INV.00000042', $message);
+    }
+
+    #[Test]
+    public function custom_concept_footer_message_is_used_for_unissued_invoice(): void
+    {
+        // arrange
+        $invoice = Invoice::make();
+        $invoice->conceptFooterMessage('Custom draft message.');
+
+        // act
+        $message = $invoice->getFooterMessage();
+
+        // assert
+        $this->assertEquals('Custom draft message.', $message);
     }
 
     #[Test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customize invoice footer messages with dynamic placeholders (:amount, :date, :number).
  * Set separate footer text for draft (concept) and issued invoices.
  * Serialized invoice output now includes footer_message and concept_footer_message fields.
  * Footer output is HTML-escaped for safety; :number renders the invoice series/sequence.

* **Tests**
  * Added unit tests covering custom footer storage, serialization, and placeholder substitution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->