### PR TITLE
feat: Add credit transfer request

### DIFF
--- a/resources/lang/en/invoice.php
+++ b/resources/lang/en/invoice.php
@@ -17,5 +17,6 @@ return [
     'bank' => 'Bank:',
     'unknown' => 'Unknown',
     'payment_request' => 'We kindly request you to pay the above amount of :amount by :date to our bank account. For questions, please contact us by email.',
+    'credit_transfer_request' => 'We will transfer the above amount of :amount to your bank account by :date. For questions, please contact us by email.',
     'concept_message' => 'This is a <strong>DRAFT</strong>. This means this invoice is not yet official and no payment is required. You will receive the official invoice at a later date.',
 ];

--- a/resources/lang/nl/invoice.php
+++ b/resources/lang/nl/invoice.php
@@ -17,5 +17,6 @@ return [
     'bank' => 'Bank:',
     'unknown' => 'Onbekend',
     'payment_request' => 'We verzoeken je vriendelijk het bovenstaande bedrag van :amount voor :date te voldoen op onze bankrekening. Voor vragen kan je contact opnemen per e-mail.',
+    'credit_transfer_request' => 'Wij zullen het bovenstaande bedrag van :amount voor :date overmaken op uw bankrekening. Voor vragen kan je contact opnemen per e-mail.',
     'concept_message' => 'Dit is een <strong>CONCEPT</strong>. Dit betekent dat deze factuur nog niet officieel is en er nog geen betaling vereist is. Je ontvangt de officiële factuur op een later moment.',
 ];

--- a/resources/lang/nl/invoice.php
+++ b/resources/lang/nl/invoice.php
@@ -17,6 +17,6 @@ return [
     'bank' => 'Bank:',
     'unknown' => 'Onbekend',
     'payment_request' => 'We verzoeken je vriendelijk het bovenstaande bedrag van :amount voor :date te voldoen op onze bankrekening. Voor vragen kan je contact opnemen per e-mail.',
-    'credit_transfer_request' => 'Wij zullen het bovenstaande bedrag van :amount voor :date overmaken op uw bankrekening. Voor vragen kan je contact opnemen per e-mail.',
+    'credit_transfer_request' => 'We zullen het bovenstaande bedrag van :amount voor :date overmaken op je bankrekening. Voor vragen kan je contact opnemen per e-mail.',
     'concept_message' => 'Dit is een <strong>CONCEPT</strong>. Dit betekent dat deze factuur nog niet officieel is en er nog geen betaling vereist is. Je ontvangt de officiële factuur op een later moment.',
 ];

--- a/src/Models/Traits/HasInvoiceFooter.php
+++ b/src/Models/Traits/HasInvoiceFooter.php
@@ -2,6 +2,8 @@
 
 namespace SimpleParkBv\Invoices\Models\Traits;
 
+use SimpleParkBv\Invoices\Services\CurrencyFormatter;
+
 /**
  * Trait HasInvoiceFooter
  */
@@ -69,10 +71,19 @@ trait HasInvoiceFooter
             return __('invoices::invoice.concept_message');
         }
 
-        /** @var string $message */
-        $message = e($this->footerMessage ?? __('invoices::invoice.payment_request'));
+        $isNegativeTotal = $this->footerMessage === null && $this->getTotal() < 0;
 
-        $amountHtml = '<span class="invoice__footer-amount">'.e($this->getFormattedTotal()).'</span>';
+        /** @var string $message */
+        $message = e($this->footerMessage ?? ($isNegativeTotal
+            ? __('invoices::invoice.credit_transfer_request')
+            : __('invoices::invoice.payment_request')
+        ));
+
+        $formattedAmount = $isNegativeTotal
+            ? CurrencyFormatter::format(abs($this->getTotal()))
+            : $this->getFormattedTotal();
+
+        $amountHtml = '<span class="invoice__footer-amount">'.e($formattedAmount).'</span>';
         $dateHtml = '<span class="invoice__footer-date">'.e($this->getFormattedDueDate()).'</span>';
         $numberHtml = '<span class="invoice__footer-number">'.e($this->getNumber() ?? '').'</span>';
 

--- a/tests/Unit/Models/InvoiceTest.php
+++ b/tests/Unit/Models/InvoiceTest.php
@@ -944,6 +944,47 @@ final class InvoiceTest extends TestCase
     }
 
     #[Test]
+    public function footer_message_for_negative_total_shows_credit_transfer_message(): void
+    {
+        // arrange
+        $invoice = Invoice::make();
+        $buyer = Buyer::make(['name' => 'Test Buyer']);
+        $invoice->buyer($buyer);
+        $item = $this->createInvoiceItem(['title' => 'Credit', 'unit_price' => -10.00]);
+        $invoice->addItem($item);
+        $invoice->date('2024-01-15');
+        $invoice->payUntilDays(30);
+
+        // act
+        $message = $invoice->getFooterMessage();
+
+        // assert
+        $this->assertStringContainsString('transfer', $message);
+        $this->assertStringContainsString('10,00', $message);
+        $this->assertStringNotContainsString('-10,00', $message);
+    }
+
+    #[Test]
+    public function custom_footer_message_overrides_credit_transfer_for_negative_total(): void
+    {
+        // arrange
+        $invoice = Invoice::make();
+        $buyer = Buyer::make(['name' => 'Test Buyer']);
+        $invoice->buyer($buyer);
+        $item = $this->createInvoiceItem(['title' => 'Credit', 'unit_price' => -10.00]);
+        $invoice->addItem($item);
+        $invoice->date('2024-01-15');
+        $invoice->payUntilDays(30);
+        $invoice->footerMessage('Custom message with :amount.');
+
+        // act
+        $message = $invoice->getFooterMessage();
+
+        // assert
+        $this->assertStringContainsString('Custom message with', $message);
+    }
+
+    #[Test]
     #[DataProvider('set_logo_data_provider')]
     public function set_logo(?string $logoPath, ?string $initialLogo, ?string $expected): void
     {


### PR DESCRIPTION
Adds the `credit_transfer_request` for negative invoices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized invoice footer message for credit notes/negative totals (English and Dutch), including amount/date placeholders and bank transfer wording.
* **Bug Fixes**
  * Updated invoice footer generation so negative totals show a credit-transfer request with a positive formatted amount.
  * If a custom footer message is set, it’s still used as-is for negative totals.
* **Tests**
  * Added unit coverage for negative-total footer messaging and custom-message override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->